### PR TITLE
Add ARPES reader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ BROWSER := python -c "$$BROWSER_PYSCRIPT"
 help:
 	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
 
-kaitai: src/htmdec_formats/ksy_files/nmdfile.py src/htmdec_formats/ksy_files/simple_xls.py ## rebuild kaitai .py files from .ksy files
+kaitai: src/htmdec_formats/ksy_files/nmdfile.py src/htmdec_formats/ksy_files/simple_xls.py src/htmdec_formats/ksy_files/pxtfile.py ## rebuild kaitai .py files from .ksy files
 
 %.py : %.ksy
 	ksc --target=python --python-package=htmdec_formats.ksy_files --outdir=$(dir $@) $<

--- a/src/htmdec_formats/__init__.py
+++ b/src/htmdec_formats/__init__.py
@@ -5,3 +5,4 @@ __email__ = "matthewturk@gmail.com"
 __version__ = "0.1.0"
 
 from .indenter_formats import IndenterDataset
+from .arpes_formats import ARPESDataset

--- a/src/htmdec_formats/arpes_formats.py
+++ b/src/htmdec_formats/arpes_formats.py
@@ -45,7 +45,6 @@ class ARPESDataset:
             [_.value for _ in pxt_file.wave.layers],
             (max(self.num_layers, 1), self.num_cols, self.num_rows),
         )
-        import pdb
 
         if "\r\r" in pxt_file.metadata:
             md, self.dims = pxt_file.metadata.rsplit("\r\r", 1)
@@ -85,3 +84,13 @@ class ARPESDataset:
         if layer > self.num_layers or layer < 1:
             raise IndexError(f"Layer {layer} is out of bounds.")
         return self.array_data[layer - 1, :, :]
+
+    def to_hdf5(self, filename: str):
+        """Write the data to an HDF5 file."""
+        import h5py
+
+        with h5py.File(filename, "w") as f:
+            dataset = f.create_dataset("data", data=self.array_data)
+            dataset.attrs["bounds"] = self.bounds
+            dataset.attrs["dims"] = self.dims
+            dataset.attrs["metadata"] = self._metadata

--- a/src/htmdec_formats/arpes_formats.py
+++ b/src/htmdec_formats/arpes_formats.py
@@ -1,0 +1,70 @@
+"""
+Formats for the ARPES data, specifically their sub-dialect of pxt
+"""
+
+import sys
+
+try:
+    from .ksy_files.pxtfile import Pxtfile as KaitaiPxtfile
+except ImportError as e:
+    print(f"Error: {e}")
+    print("Please run 'make install' to install the necessary dependencies.")
+    sys.exit(1)
+
+import numpy as np
+
+
+class ARPESDataset:
+    pxt_file: KaitaiPxtfile
+    num_rows: int
+    num_cols: int
+    num_layers: int
+
+    row_start: float
+    col_start: float
+    layer_start: float
+
+    row_delta: float
+    col_delta: float
+    layer_delta: float
+
+    def __init__(self, pxt_file: KaitaiPxtfile):
+        self.pxt_file = pxt_file
+        for attr in ["row", "col", "layer"]:
+            setattr(self, f"num_{attr}s", getattr(pxt_file.wave, f"num_{attr}s"))
+            setattr(self, f"{attr}_start", getattr(pxt_file.wave, f"{attr}_start"))
+            setattr(self, f"{attr}_delta", getattr(pxt_file.wave, f"{attr}_delta"))
+        self.array_data = np.reshape(
+            [_.value for _ in pxt_file.wave.layers],
+            (self.num_layers, self.num_cols, self.num_rows),
+        )
+
+    @property
+    def bounds(self):
+        return np.array(
+            [
+                [
+                    self.layer_start,
+                    self.layer_start + self.layer_delta * self.num_layers,
+                ],
+                [
+                    self.col_start,
+                    self.col_start + self.col_delta * self.num_cols,
+                ],
+                [
+                    self.row_start,
+                    self.row_start + self.row_delta * self.num_rows,
+                ],
+            ]
+        )
+
+    @classmethod
+    def from_file(cls, filename: str) -> "ARPESDataset":
+        return cls(KaitaiPxtfile.from_file(filename))
+
+    def get_layer(self, layer: int) -> np.ndarray:
+        """This function returns a 2D numpy array of the data for a given layer.
+        It is 1-indexed, not zero-indexed.."""
+        if layer > self.num_layers or layer < 1:
+            raise IndexError(f"Layer {layer} is out of bounds.")
+        return self.array_data[layer - 1, :, :]

--- a/src/htmdec_formats/cli.py
+++ b/src/htmdec_formats/cli.py
@@ -92,5 +92,12 @@ def pxt_info_query(
             console.print(f"  {key}: {dataset.metadata[section][key]}")
 
 
+@app.command()
+def pxt_to_hdf5(pxtfile: str, outfile: str):
+    """Convert a PXT file to an HDF5 file."""
+    dataset = htmdec_formats.ARPESDataset.from_file(pxtfile)
+    dataset.to_hdf5(outfile)
+
+
 if __name__ == "__main__":
     app()

--- a/src/htmdec_formats/cli.py
+++ b/src/htmdec_formats/cli.py
@@ -4,6 +4,8 @@ import htmdec_formats
 
 import typer
 from rich.console import Console
+from typing import Optional
+from typing_extensions import Annotated
 
 app = typer.Typer()
 console = Console()
@@ -38,6 +40,56 @@ def nmd_extract_xml(nmdfile: str, outfile: str):
     """Extract the XML from an NMD file."""
     dataset = htmdec_formats.IndenterDataset.from_filename(nmdfile)
     dataset._xml_tree.write(outfile)
+
+
+@app.command()
+def pxt_describe(pxtfile: str):
+    """Describe the contents of a PXT file."""
+    dataset = htmdec_formats.ARPESDataset.from_file(pxtfile)
+    console.print()
+    for line in dataset._metadata.splitlines():
+        console.print(line)
+    console.print()
+    console.print("[bold]Sections:[/bold]")
+    for section in dataset.metadata.sections():
+        console.print(section)
+    console.print()
+    console.print("[bold]Bounds:[/bold]")
+    console.print(dataset.bounds)
+    console.print()
+    console.print("[bold]Data shape:[/bold]")
+    console.print(dataset.array_data.shape)
+
+
+@app.command()
+def pxt_info_export(pxtfile: str, outfile: str):
+    """Export the metadata of a PXT file to a file."""
+    dataset = htmdec_formats.ARPESDataset.from_file(pxtfile)
+    with open(outfile, "w") as f:
+        l = f.write(dataset._metadata)
+        console.print(f"Output {l} bytes to {outfile}.")
+
+
+@app.command()
+def pxt_info_query(
+    pxtfile: str, section: str, key: Annotated[Optional[str], typer.Argument()] = None
+):
+    """Query the metadata of a PXT file."""
+    dataset = htmdec_formats.ARPESDataset.from_file(pxtfile)
+    if section not in dataset.metadata:
+        console.print(f"Section {section} not found.")
+        return
+    if key is not None:
+        if key not in dataset.metadata[section]:
+            console.print(f"Key {key} not found in section {section}.")
+            return
+        console.print(
+            f"[bold]{section} -> {key}[/bold]: {dataset.metadata[section][key]}"
+        )
+    else:
+        console.print(f"[bold]{section}[/bold]:")
+        for key in dataset.metadata[section]:
+            console.print(f"  {key}: {dataset.metadata[section][key]}")
 
 
 if __name__ == "__main__":

--- a/src/htmdec_formats/indenter_formats.py
+++ b/src/htmdec_formats/indenter_formats.py
@@ -108,11 +108,11 @@ class IndenterDataset:
         for test in self._xml_tree.findall("TEST"):
             self.tests.append(IndenterTest(test, buffers))
 
-    @staticmethod
-    def from_filename(filename: str) -> "IndenterDataset":
+    @classmethod
+    def from_filename(cls, filename: str) -> "IndenterDataset":
         """Creates an IndenterDataset object from a .nmd file."""
         nmd: Nmdfile = Nmdfile.from_filename(filename)
-        return IndenterDataset(nmd)
+        return cls(nmd)
 
     def to_df(self) -> pd.DataFrame:
         """Converts a .nmd file to a concatenated set of pandas DataFrames."""

--- a/src/htmdec_formats/ksy_files/pxtfile.ksy
+++ b/src/htmdec_formats/ksy_files/pxtfile.ksy
@@ -1,0 +1,77 @@
+meta:
+  id: pxtfile
+  file-extension: pxtfile
+  endian: le
+seq:
+  - id: unk1
+    type: u2
+  - id: unk2
+    type: u2
+  - id: unk3
+    type: u4
+  - id: unk4
+    type: u2
+  - id: unk5
+    type: u2
+  - id: wave_size
+    type: u4
+  - id: wave1
+    type: wave_data
+    size: wave_size + 40
+  - id: unk7
+    type: u4
+    repeat: expr
+    repeat-expr: 4
+  - id: metadata
+    type: str
+    encoding: utf-8
+    size-eos: true
+types:
+  wave_data:
+    seq:
+      - id: unk0
+        type: u4
+        repeat: expr
+        repeat-expr: 21
+      - id: name
+        type: str
+        encoding: utf-8
+        size: 40
+      - id: num_rows
+        type: u4
+      - id: num_cols
+        type: u4
+      - id: num_layers
+        type: u4
+      - id: unk1
+        type: u4
+      - id: row_delta
+        type: f8
+      - id: column_delta
+        type: f8
+      - id: layer_delta
+        type: f8
+      - id: unk2
+        type: f8
+      - id: row_start
+        type: f8
+      - id: column_start
+        type: f8
+      - id: layer_start
+        type: f8
+      - id: unk4
+        type: f8
+      - id: unk5
+        type: f4
+        repeat: expr
+        repeat-expr: 39
+      - id: layers
+        repeat: expr
+        repeat-expr: "num_layers > 0 ? num_layers : 1"
+        type: layer
+  layer:
+    seq:
+      - id: value
+        type: f4
+        repeat: expr
+        repeat-expr: "(_parent.num_rows > 0 ? _parent.num_rows : 1) * (_parent.num_cols > 0 ? _parent.num_cols : 1)"

--- a/src/htmdec_formats/ksy_files/pxtfile.ksy
+++ b/src/htmdec_formats/ksy_files/pxtfile.ksy
@@ -15,7 +15,7 @@ seq:
     type: u2
   - id: wave_size
     type: u4
-  - id: wave1
+  - id: wave
     type: wave_data
     size: wave_size + 40
   - id: unk7
@@ -47,7 +47,7 @@ types:
         type: u4
       - id: row_delta
         type: f8
-      - id: column_delta
+      - id: col_delta
         type: f8
       - id: layer_delta
         type: f8
@@ -55,7 +55,7 @@ types:
         type: f8
       - id: row_start
         type: f8
-      - id: column_start
+      - id: col_start
         type: f8
       - id: layer_start
         type: f8


### PR DESCRIPTION
This adds a reader for ARPES data in the PXT container format.

The following new commands are available:

 - `pxt-describe` to get information about bounds, the metadata (in INI format) and the array shape
 - `pxt-info-query` to query the PXT metadata (INI format) for specific sections or keys within sections
 - `pxt-info-export` to dump the INI stuff to a file
 - `pxt-to-hdf5` for converting the array data (and metadata) to HDF5, if h5py is installed.
